### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const cipher = new Rijndael(key, 'cbc');
 // Output will always be <Array> where every element is an integer <Number>
 const ciphertext = Buffer.from(cipher.encrypt(original, '256', iv));
 
-ciphertext.toString("base64");
+ciphertext.toString('base64');
 // -> bmwLDaLiI1k0oUu5wx9dlWs+Uuw3IhIkMYvq0VsVlQY66wAAqS0djh8N+SZJNHsv8wBRfhytRX2p9LJ0GT3sig==
 
 // `Rijndael.decrypt(ciphertext, blockSize[, iv]) -> <Array>`

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ const cipher = new Rijndael(key, 'cbc');
 
 // `Rijndael.encrypt(plaintext, blockSize[, iv]) -> <Array>`
 // Output will always be <Array> where every element is an integer <Number>
-const ciphertext = Buffer.from(cipher.encrypt(original, 256, iv));
+const ciphertext = Buffer.from(cipher.encrypt(original, '256', iv));
 
 ciphertext.toString("base64");
 // -> bmwLDaLiI1k0oUu5wx9dlWs+Uuw3IhIkMYvq0VsVlQY66wAAqS0djh8N+SZJNHsv8wBRfhytRX2p9LJ0GT3sig==
 
 // `Rijndael.decrypt(ciphertext, blockSize[, iv]) -> <Array>`
-const plaintext = Buffer.from(cipher.decrypt(ciphertext, 256, iv));
+const plaintext = Buffer.from(cipher.decrypt(ciphertext, '256', iv));
 
 original === plaintext.toString();
 // -> true


### PR DESCRIPTION
### Sumarry
Made two changes to improve README.md

### Changes
1. Change the type of blocksize from number to string.
    * Looking at https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/rijndael-js/index.d.ts . 　BlockSize which is an argument of `decrypt` and `encrypt`  is string type. Therefore, the usage should also be of type string.
2. Eliminate double quotes
    * In the usage, single and double quote  are mixed up. It unify to single quote to improve the appearance.
